### PR TITLE
Increase FreeRADIUS max_sessions to 16384

### DIFF
--- a/radius/mods-enabled/eap
+++ b/radius/mods-enabled/eap
@@ -3,7 +3,7 @@
 		timer_expire     = 60
 		ignore_unknown_eap_types = no
 		cisco_accounting_username_bug = no
-		max_sessions = 4096
+		max_sessions = 16384
 		tls {
 			tls_min_version = "1.0"
 			certificate_file = ${certdir}/server.pem


### PR DESCRIPTION
Raised `max_sessions` to 16384 to prevent session tracking limits.

This change addresses issues observed in the recent GovWifi incident where the default limit caused dropped sessions and authentication failures

https://technologyprogramme.atlassian.net/browse/GW-2361